### PR TITLE
Add Travis integration, test rubies 2.5-2.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,24 @@
+language: ruby
+rvm:
+- 2.5.7
+- 2.6.5
+- 2.7.0
+
+services:
+  - redis-server
+
+env:
+  - TEST_REDIS_URL=redis://localhost:6379
+
+before_install:
+  - gem install bundler
+
+script:
+  - bundle exec rake test
+
+jobs:
+  include:
+    - rvm: '2.5.1'
+      before_install:
+        - gem update --system
+        - gem install bundler

--- a/lib/sidekiq/heroku_autoscale.rb
+++ b/lib/sidekiq/heroku_autoscale.rb
@@ -16,7 +16,7 @@ module Sidekiq
 
       def init(options)
         options = options.transform_keys(&:to_sym)
-        @app = HerokuApp.new(options)
+        @app = HerokuApp.new(**options)
 
         ::Sidekiq.logger.warn('Heroku platform API is not configured for Sidekiq::HerokuAutoscale') unless @app.live?
 

--- a/lib/sidekiq/heroku_autoscale/process.rb
+++ b/lib/sidekiq/heroku_autoscale/process.rb
@@ -24,8 +24,8 @@ module Sidekiq
         @app_name = app_name || name.to_s
         @name = name.to_s
         @client = client
-        @queue_system = QueueSystem.new(system)
-        @scale_strategy = ScaleStrategy.new(scale)
+        @queue_system = QueueSystem.new(**system)
+        @scale_strategy = ScaleStrategy.new(**scale)
 
         @dynos = 0
         @active_at = nil

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -5,7 +5,7 @@ require 'minitest/pride'
 require 'minitest/autorun'
 require 'sidekiq-heroku-autoscale'
 
-Sidekiq.redis = Sidekiq::RedisConnection.create(:url => 'redis://localhost:9736')
+Sidekiq.redis = Sidekiq::RedisConnection.create(:url => ENV.fetch('TEST_REDIS_URL', 'redis://localhost:9736'))
 Sidekiq.logger = ::Logger.new(STDOUT)
 Sidekiq.logger.level = ::Logger::ERROR
 

--- a/test/unit/process_test.rb
+++ b/test/unit/process_test.rb
@@ -5,8 +5,8 @@ describe 'Sidekiq::HerokuAutoscale::Process' do
 
   before do
     Sidekiq.redis {|c| c.flushdb }
-    @subject = ::Sidekiq::HerokuAutoscale::Process.new(TEST_CONFIG)
-    @subject2 = ::Sidekiq::HerokuAutoscale::Process.new(TEST_CONFIG)
+    @subject = ::Sidekiq::HerokuAutoscale::Process.new(**TEST_CONFIG)
+    @subject2 = ::Sidekiq::HerokuAutoscale::Process.new(**TEST_CONFIG)
   end
 
   describe 'throttled?' do
@@ -323,7 +323,7 @@ describe 'Sidekiq::HerokuAutoscale::Process' do
 
   describe 'fetch_dyno_count' do
     before do
-      @subject = ::Sidekiq::HerokuAutoscale::Process.new(TEST_CONFIG.merge(client: TestClient.new))
+      @subject = ::Sidekiq::HerokuAutoscale::Process.new(**TEST_CONFIG.merge(client: TestClient.new))
     end
 
     it 'fetches total dynos for a process type via PlatformAPI' do
@@ -342,7 +342,7 @@ describe 'Sidekiq::HerokuAutoscale::Process' do
 
   describe 'set_dyno_count!' do
     before do
-      @subject = ::Sidekiq::HerokuAutoscale::Process.new(TEST_CONFIG.merge(client: TestClient.new))
+      @subject = ::Sidekiq::HerokuAutoscale::Process.new(**TEST_CONFIG.merge(client: TestClient.new))
     end
 
     it 'sets total dynos for a process type via PlatformAPI, and syncs count' do


### PR DESCRIPTION
- Add travis-ci.org integration, 
- Test for rubies 2.5 through 2.7
- Fix compatibility warnings for ruby 2.7