### PR TITLE
Adding minimum workers to linear scaling strategy & also fixing scaling down of unused workers

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     sidekiq-heroku-autoscale (0.0.1)
-      platform-api (~> 2.0)
+      platform-api (~> 3.3.0)
       sidekiq (>= 5.0)
 
 GEM
@@ -19,7 +19,7 @@ GEM
     minitest (5.13.0)
     moneta (1.0.0)
     multi_json (1.14.1)
-    platform-api (2.2.0)
+    platform-api (3.3.0)
       heroics (~> 0.0.25)
       moneta (~> 1.0.0)
     rack (2.0.8)

--- a/lib/sidekiq/heroku_autoscale/scale_strategy.rb
+++ b/lib/sidekiq/heroku_autoscale/scale_strategy.rb
@@ -44,7 +44,8 @@ module Sidekiq
         # don't scale down past number of currently engaged workers,
         # and don't scale up past maximum dynos
         ideal_dynos = ([0, scaled_capacity_percentage].max * @max_dynos).ceil
-        minimum_dynos = [sys.dynos, ideal_dynos, @min_dynos].max
+        #minimum_dynos = [sys.dynos, ideal_dynos, @min_dynos].max
+        minimum_dynos = [ideal_dynos, @min_dynos].max
         maximum_dynos = [minimum_dynos, @max_dynos].min
         [minimum_dynos, maximum_dynos].min
       end

--- a/lib/sidekiq/heroku_autoscale/scale_strategy.rb
+++ b/lib/sidekiq/heroku_autoscale/scale_strategy.rb
@@ -44,7 +44,6 @@ module Sidekiq
         # don't scale down past number of currently engaged workers,
         # and don't scale up past maximum dynos
         ideal_dynos = ([0, scaled_capacity_percentage].max * @max_dynos).ceil
-        #minimum_dynos = [sys.dynos, ideal_dynos, @min_dynos].max
         minimum_dynos = [ideal_dynos, @min_dynos].max
         maximum_dynos = [minimum_dynos, @max_dynos].min
         [minimum_dynos, maximum_dynos].min

--- a/lib/sidekiq/heroku_autoscale/scale_strategy.rb
+++ b/lib/sidekiq/heroku_autoscale/scale_strategy.rb
@@ -2,11 +2,12 @@ module Sidekiq
   module HerokuAutoscale
 
     class ScaleStrategy
-      attr_accessor :mode, :max_dynos, :workers_per_dyno, :min_factor
+      attr_accessor :mode, :max_dynos, :min_dynos, :workers_per_dyno, :min_factor
 
-      def initialize(mode: :binary, max_dynos: 1, workers_per_dyno: 25, min_factor: 0)
+      def initialize(mode: :binary, max_dynos: 1, min_dynos: 0, workers_per_dyno: 25, min_factor: 0)
         @mode = mode
         @max_dynos = max_dynos
+        @min_dynos = min_dynos
         @workers_per_dyno = workers_per_dyno
         @min_factor = min_factor
       end
@@ -43,7 +44,7 @@ module Sidekiq
         # don't scale down past number of currently engaged workers,
         # and don't scale up past maximum dynos
         ideal_dynos = ([0, scaled_capacity_percentage].max * @max_dynos).ceil
-        minimum_dynos = [sys.dynos, ideal_dynos].max
+        minimum_dynos = [sys.dynos, ideal_dynos, @min_dynos].max
         maximum_dynos = [minimum_dynos, @max_dynos].min
         [minimum_dynos, maximum_dynos].min
       end

--- a/sidekiq-heroku-autoscale.gemspec
+++ b/sidekiq-heroku-autoscale.gemspec
@@ -17,5 +17,5 @@ Gem::Specification.new do |s|
   s.licenses    = ['MIT']
 
   s.add_dependency 'sidekiq', '>= 5.0'
-  s.add_dependency 'platform-api', '~> 2.0'
+  s.add_dependency 'platform-api', '~> 3.3.0'
 end


### PR DESCRIPTION
Thanks for the awesome repo.

1) Adding 'minimum workers' configuration should be straightforward.

2) I'm surprised the linear strategy doesn't scale workers down as it will always keep the existing idle works up and running. I believe this change fixes it? 